### PR TITLE
add tab_width and indent_size consistent with WordPress and Woo repos

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,9 +9,11 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
-indent_style = tab
 
 [{.jshintrc,*.json,*.yml,*.env}]
 indent_style = space


### PR DESCRIPTION
This PR updates the repo [EditorConfig](https://editorconfig.org) so tab indentation defaults to a width of 4. EditorConfig helps ensure various different text editors all use the same indentation settings. 

The tweaked settings make this repo more consistent with WordPress core and other WooCommerce plugins.