### PR TITLE
Regenerate indexes after filtering.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -198,6 +198,11 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$image_urls = array_merge( $image_urls, $this->get_gallery_urls() );
 			$image_urls = array_filter( array_unique( $image_urls ) );
 
+			// Regenerate indexes after filtering.
+			// The array_filter does not touches indexes so we may end up with gaps.
+			// Later parts of the code expect something to exist under the 0 index.
+			$image_urls = array_values( $image_urls );
+
 			if ( empty( $image_urls ) ) {
 				// TODO: replace or remove this placeholder - placeholdit.imgix.net is no longer available {WV 2020-01-21}
 				$image_urls[] = sprintf( 'https://placeholdit.imgix.net/~text?txtsize=33&name=%s&w=530&h=530', rawurlencode( strip_tags( $this->woo_product->get_title() ) ) );
@@ -215,7 +220,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 		 *
 		 * @since 2.0.2
 		 *
-		 * @param array $image_urls all image URLs for the product
+		 * @param array $image_urls all image URLs for the product.
 		 * @return array
 		 */
 		private function get_additional_image_urls( $image_urls ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -198,8 +198,8 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$image_urls = array_merge( $image_urls, $this->get_gallery_urls() );
 			$image_urls = array_filter( array_unique( $image_urls ) );
 
-			// Regenerate indexes after filtering.
-			// The array_filter does not touches indexes so we may end up with gaps.
+			// Regenerate $image_url PHP array indexes after filtering.
+			// The array_filter does not touches indexes so if something gets removed we may end up with gaps.
 			// Later parts of the code expect something to exist under the 0 index.
 			$image_urls = array_values( $image_urls );
 


### PR DESCRIPTION
Fixes: #1825

If the product has no image set but the product gallery has images we may end up with URL array that has no index '0'. Parts of the code expect something to always be present at the index `0`. Regenerating indexes solves this issue.

## Testing:
1. Create a product with no image set but with images in the gallery:
![image](https://user-images.githubusercontent.com/17271089/112284474-926da700-8c89-11eb-8c5e-64ed6a78e172.png)
2. Sync the product.

Outcome: without this PR the error from #1825 is logged. With this PR the error is not logged and a valid image URL is appended.

## Changelog:
- Fix: Undefined array key error for products without 'Product image' set.